### PR TITLE
Refactor/use ckanext switzerland env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
           pip install -e git+https://github.com/ckan/ckanext-fluent.git#egg=ckanext-fluent
           pip install -e git+https://github.com/ckan/ckanext-harvest.git#egg=ckanext-harvest
           pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/master/requirements.txt
+          pip install -e git+https://github.com/opendata-swiss/ckanext-harvester_dashboard.git@feat/upgrade_to_py3#egg=ckanext-harvester_dashboard
           pip install -e git+https://github.com/ckan/ckanext-hierarchy.git#egg=ckanext-hierarchy
           pip install -r https://raw.githubusercontent.com/ckan/ckanext-hierarchy/master/requirements.txt
           pip install -e git+https://github.com/opendata-swiss/ckanext-password-policy.git@feat/upgrade_to_py3#egg=ckanext-password-policy

--- a/ckanext/switzerland_users/helpers.py
+++ b/ckanext/switzerland_users/helpers.py
@@ -1,4 +1,3 @@
-import ckan.plugins.toolkit as tk
 from ckan.lib.helpers import link_to, linked_user, url_for
 
 from ckanext.switzerland.helpers.frontend_helpers import get_localized_value_for_display
@@ -49,7 +48,3 @@ def ogdch_display_memberships(user):
         memberships_display = ", ".join(memberships_display)
 
     return memberships_display
-
-
-def ogdch_get_env():
-    return tk.config.get("ckanext.switzerland_users.env", "test")

--- a/ckanext/switzerland_users/plugin.py
+++ b/ckanext/switzerland_users/plugin.py
@@ -45,7 +45,6 @@ class OgdchUsersPlugin(plugins.SingletonPlugin, DefaultTranslation):
         """
         return {
             "ogdch_list_user": ogdch_user_helpers.ogdch_list_user,
-            "ogdch_get_env": ogdch_user_helpers.ogdch_get_env,
         }
 
     # IBlueprint

--- a/ckanext/switzerland_users/tests/test_blueprints.py
+++ b/ckanext/switzerland_users/tests/test_blueprints.py
@@ -117,7 +117,10 @@ def _request_user_list_and_get_users(app, auth_headers, role=None, organization=
     return fullnames, usernames
 
 
-@pytest.mark.ckan_config("ckan.plugins", "ogdch ogdch_users ogdch_org ogdch_showcase")
+@pytest.mark.ckan_config(
+    "ckan.plugins",
+    "ogdch ogdch_users ogdch_org ogdch_showcase harvester_dashboard harvest",
+)
 @pytest.mark.ckan_config("ckan.auth.public_user_details", False)
 @pytest.mark.ckan_config("ckanext.switzerland.send_email_on_user_registration", False)
 @pytest.mark.usefixtures("with_plugins", "clean_db", "clean_index")

--- a/test.ini
+++ b/test.ini
@@ -17,7 +17,7 @@ use = config:../../src/ckan/test-core.ini
 ckan.legacy_templates = false
 ckan.plugins = ogdch_users hierarchy_display
 
-ckanext.switzerland_users.env = test
+ckanext.switzerland.env = test
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
refactor: Use ckanext.switzerland.env config option, don't define it again

We will always have ckanext-switzerland-ng installed when using this extension, so there's no point in defining an identical config option twice and risking them getting out of sync.